### PR TITLE
Add initial admin UI with basic auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,14 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/org/acme/admin/AdminResource.java
+++ b/src/main/java/org/acme/admin/AdminResource.java
@@ -1,0 +1,26 @@
+package org.acme.admin;
+
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/admin")
+public class AdminResource {
+
+    @Inject
+    @Location("admin/index")
+    Template index;
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    @RolesAllowed("admin")
+    public TemplateInstance index() {
+        return index.instance();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+quarkus.http.auth.basic=true
+quarkus.security.users.embedded.enabled=true
+quarkus.security.users.embedded.plain-text=true
+quarkus.security.users.embedded.users.admin=secret
+quarkus.security.users.embedded.roles.admin=admin
+quarkus.datasource.devservices.enabled=false

--- a/src/main/resources/templates/admin/index.html
+++ b/src/main/resources/templates/admin/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>EquiScheduler Admin</title>
+</head>
+<body>
+    <div id="navigation">
+        {#include admin/navigation}{/include}
+    </div>
+    <main>
+        <h1>Welcome to the EquiScheduler Admin Interface</h1>
+    </main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/navigation.html
+++ b/src/main/resources/templates/admin/navigation.html
@@ -1,0 +1,5 @@
+<nav>
+    <ul>
+        <li><a href="/admin/">Home</a></li>
+    </ul>
+</nav>

--- a/src/test/java/org/acme/AdminResourceIT.java
+++ b/src/test/java/org/acme/AdminResourceIT.java
@@ -1,0 +1,8 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class AdminResourceIT extends AdminResourceTest {
+    // tests are inherited
+}

--- a/src/test/java/org/acme/AdminResourceTest.java
+++ b/src/test/java/org/acme/AdminResourceTest.java
@@ -1,0 +1,29 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+class AdminResourceTest {
+
+    @Test
+    void testAdminEndpointProtected() {
+        given()
+          .when().get("/admin")
+          .then()
+             .statusCode(401);
+    }
+
+    @Test
+    void testAdminEndpointWithAuth() {
+        given()
+          .auth().preemptive().basic("admin", "secret")
+          .when().get("/admin")
+          .then()
+             .statusCode(200)
+             .body(containsString("Welcome to the EquiScheduler Admin Interface"));
+    }
+}


### PR DESCRIPTION
## Summary
- secure `/admin` endpoint using a basic user from application properties
- render admin page via Qute templates with a navigation include
- add tests for the protected admin endpoint
- enable Elytron security properties file support

## Testing
- `./mvnw compile`
- `./mvnw verify`


------
https://chatgpt.com/codex/tasks/task_e_6854305ee6248328b6ce30da1563baa9