### PR TITLE
Add Student entity

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -89,6 +89,16 @@ The EquiScheduler is a comprehensive and user-friendly platform designed to stre
     * There must be a mechanism to assign a "teacher" role to a user.
     * Admins must have the ability to view a list of all users and delete them.
 
+### 3.5. Student Management
+
+* **Description:** This feature allows the admin to manage student records for riders like Alex.
+* **User Stories:**
+    * As an admin, I want to create and update student contact information.
+    * As an admin, I want to delete student profiles when they are no longer active.
+* **Acceptance Criteria:**
+    * The system must support a student profile with first name, last name, email, and phone number.
+    * A list of all students must be viewable with edit and delete options.
+
 **4. User Features**
 
 ### 4.1. Calendar Viewing

--- a/src/main/java/org/acme/domain/Student.java
+++ b/src/main/java/org/acme/domain/Student.java
@@ -1,0 +1,18 @@
+package org.acme.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Student {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    public String firstName;
+    public String lastName;
+    public String email;
+    public String phone;
+}

--- a/src/main/java/org/acme/repository/StudentRepository.java
+++ b/src/main/java/org/acme/repository/StudentRepository.java
@@ -1,0 +1,9 @@
+package org.acme.repository;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.acme.domain.Student;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+
+@ApplicationScoped
+public class StudentRepository implements PanacheRepository<Student> {
+}

--- a/src/test/java/org/acme/StudentRepositoryTest.java
+++ b/src/test/java/org/acme/StudentRepositoryTest.java
@@ -1,0 +1,40 @@
+package org.acme;
+
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.acme.domain.Student;
+import org.acme.repository.StudentRepository;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class StudentRepositoryTest {
+
+    @Inject
+    StudentRepository repository;
+
+    @Test
+    @TestTransaction
+    void crudStudent() {
+        Student student = new Student();
+        student.firstName = "Alex";
+        repository.persist(student);
+
+        assertNotNull(student.id);
+
+        Student found = repository.findById(student.id);
+        assertEquals("Alex", found.firstName);
+
+        found.firstName = "Taylor";
+        repository.persist(found);
+        repository.flush();
+
+        Student updated = repository.findById(student.id);
+        assertEquals("Taylor", updated.firstName);
+
+        repository.delete(updated);
+        assertNull(repository.findById(student.id));
+    }
+}


### PR DESCRIPTION
## What changed?
- introduced `Student` domain class
- added repository and CRUD test for students
- documented student management in PRD

## Why?
- riders like PRD user Alex need a persistent profile

## Breaking changes?
- none

------
https://chatgpt.com/codex/tasks/task_e_68543bcb18cc832884bb2de206c99b42