### PR TITLE
Add instructor activation and preferred instructor field

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -43,11 +43,13 @@ The EquiScheduler is a comprehensive and user-friendly platform designed to stre
     * As an admin, I want to be able to modify an instructor's details, such as their available hours per day and the days of the week they work.
     * As an admin, I want to define the standard slot length for lessons offered by each instructor (e.g., 30, 45, or 60 minutes).
     * As an admin, I want to be able to delete an instructor who is no longer with the stable.
+    * As an admin, I want to temporarily disable an instructor from being booked without deleting them.
 * **Acceptance Criteria:**
     * The system must allow for the creation of a new instructor with fields for first name, last name, email, phone number, and a notes section.
     * An availability matrix (days of the week and time ranges) must be configurable for each instructor.
     * The admin must be able to set a default lesson slot duration for each instructor.
-    * A list of all instructors must be viewable, with options to edit or delete each entry.
+    * A list of all instructors must be viewable, with options to edit, deactivate, or delete each entry.
+    * Each instructor record must include an active/inactive flag that controls booking availability.
 
 ### 3.2. Horse Management
 
@@ -94,9 +96,10 @@ The EquiScheduler is a comprehensive and user-friendly platform designed to stre
 * **Description:** This feature allows the admin to manage student records for riders like Alex.
 * **User Stories:**
     * As an admin, I want to create and update student contact information.
+    * As an admin, I want to record each student's preferred riding instructor.
     * As an admin, I want to delete student profiles when they are no longer active.
 * **Acceptance Criteria:**
-    * The system must support a student profile with first name, last name, email, and phone number.
+    * The system must support a student profile with first name, last name, email, phone number, and a preferred instructor.
     * A list of all students must be viewable with edit and delete options.
 
 **4. User Features**

--- a/src/main/java/org/acme/domain/Instructor.java
+++ b/src/main/java/org/acme/domain/Instructor.java
@@ -16,4 +16,14 @@ public class Instructor {
     public String email;
     public String phone;
     public Integer defaultSlotDuration;
+
+    /**
+     * Text description of the instructor's general availability.
+     */
+    public String availability;
+
+    /**
+     * Flag indicating if this instructor can currently be booked.
+     */
+    public boolean active = true;
 }

--- a/src/main/java/org/acme/domain/Student.java
+++ b/src/main/java/org/acme/domain/Student.java
@@ -4,6 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+/**
+ * Student entity representing a rider.
+ */
 
 @Entity
 public class Student {
@@ -15,4 +20,10 @@ public class Student {
     public String lastName;
     public String email;
     public String phone;
+
+    /**
+     * Optional preferred instructor for this student.
+     */
+    @ManyToOne
+    public Instructor preferedInstructor;
 }

--- a/src/test/java/org/acme/InstructorRepositoryTest.java
+++ b/src/test/java/org/acme/InstructorRepositoryTest.java
@@ -21,19 +21,25 @@ class InstructorRepositoryTest {
         Instructor ins = new Instructor();
         ins.firstName = "John";
         ins.lastName = "Doe";
+        ins.availability = "Weekdays";
         repository.persist(ins);
 
         assertNotNull(ins.id);
 
         Instructor found = repository.findById(ins.id);
         assertEquals("John", found.firstName);
+        assertTrue(found.active);
 
         found.firstName = "Jane";
+        found.active = false;
+        found.availability = "Weekends";
         repository.persist(found);
         repository.flush();
 
         Instructor updated = repository.findById(ins.id);
         assertEquals("Jane", updated.firstName);
+        assertFalse(updated.active);
+        assertEquals("Weekends", updated.availability);
 
         repository.delete(updated);
         assertNull(repository.findById(ins.id));

--- a/src/test/java/org/acme/StudentRepositoryTest.java
+++ b/src/test/java/org/acme/StudentRepositoryTest.java
@@ -4,7 +4,9 @@ import io.quarkus.test.TestTransaction;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.acme.domain.Student;
+import org.acme.domain.Instructor;
 import org.acme.repository.StudentRepository;
+import org.acme.repository.InstructorRepository;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,24 +17,39 @@ class StudentRepositoryTest {
     @Inject
     StudentRepository repository;
 
+    @Inject
+    InstructorRepository instructorRepository;
+
     @Test
     @TestTransaction
     void crudStudent() {
+        Instructor ins1 = new Instructor();
+        ins1.firstName = "Sam";
+        instructorRepository.persist(ins1);
+
+        Instructor ins2 = new Instructor();
+        ins2.firstName = "Jamie";
+        instructorRepository.persist(ins2);
+
         Student student = new Student();
         student.firstName = "Alex";
+        student.preferedInstructor = ins1;
         repository.persist(student);
 
         assertNotNull(student.id);
 
         Student found = repository.findById(student.id);
         assertEquals("Alex", found.firstName);
+        assertEquals(ins1.id, found.preferedInstructor.id);
 
         found.firstName = "Taylor";
+        found.preferedInstructor = ins2;
         repository.persist(found);
         repository.flush();
 
         Student updated = repository.findById(student.id);
         assertEquals("Taylor", updated.firstName);
+        assertEquals(ins2.id, updated.preferedInstructor.id);
 
         repository.delete(updated);
         assertNull(repository.findById(student.id));


### PR DESCRIPTION
## Summary
- track instructor availability and activation status
- allow students to store a preferred instructor
- cover new behaviour with repository tests
- extend PRD with new admin stories
- rename `preferredInstructor` field to `preferedInstructor`

## Testing
- `mvn -DskipITs=false test`
- `mvn -DskipITs=false verify` *(fails: Datasource `<default>` URL not set)*
- `mvn -DskipITs=true verify`


------
https://chatgpt.com/codex/tasks/task_e_68543d621e3c83289282d57758015fdd