### PR TITLE
Add admin instructor management UI

### DIFF
--- a/src/main/java/org/acme/admin/InstructorAdminResource.java
+++ b/src/main/java/org/acme/admin/InstructorAdminResource.java
@@ -1,0 +1,98 @@
+package org.acme.admin;
+
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.acme.domain.Instructor;
+import org.acme.repository.InstructorRepository;
+
+import java.util.List;
+
+@Path("/admin/instructors")
+@RolesAllowed("admin")
+public class InstructorAdminResource {
+
+    @Inject
+    InstructorRepository repository;
+
+    @Inject
+    @Location("admin/instructors")
+    Template index;
+
+    @Inject
+    @Location("admin/instructor-form")
+    Template form;
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance list() {
+        List<Instructor> instructors = repository.listAll();
+        return index.data("instructors", instructors);
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public TemplateInstance create(@FormParam("firstName") String firstName,
+                                   @FormParam("lastName") String lastName,
+                                   @FormParam("email") String email,
+                                   @FormParam("phone") String phone,
+                                   @FormParam("availability") String availability,
+                                   @FormParam("defaultSlotDuration") Integer defaultSlotDuration) {
+        Instructor instructor = new Instructor();
+        instructor.firstName = firstName;
+        instructor.lastName = lastName;
+        instructor.email = email;
+        instructor.phone = phone;
+        instructor.availability = availability;
+        instructor.defaultSlotDuration = defaultSlotDuration;
+        repository.persist(instructor);
+        return list();
+    }
+
+    @GET
+    @Path("{id}/edit")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance editForm(@PathParam("id") Long id) {
+        Instructor instructor = repository.findById(id);
+        return form.data("instructor", instructor);
+    }
+
+    @POST
+    @Path("{id}/edit")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public TemplateInstance update(@PathParam("id") Long id,
+                                   @FormParam("firstName") String firstName,
+                                   @FormParam("lastName") String lastName,
+                                   @FormParam("email") String email,
+                                   @FormParam("phone") String phone,
+                                   @FormParam("availability") String availability,
+                                   @FormParam("defaultSlotDuration") Integer defaultSlotDuration,
+                                   @FormParam("active") boolean active) {
+        Instructor instructor = repository.findById(id);
+        instructor.firstName = firstName;
+        instructor.lastName = lastName;
+        instructor.email = email;
+        instructor.phone = phone;
+        instructor.availability = availability;
+        instructor.defaultSlotDuration = defaultSlotDuration;
+        instructor.active = active;
+        repository.persist(instructor);
+        repository.flush();
+        return list();
+    }
+
+    @POST
+    @Path("{id}/toggle")
+    public TemplateInstance toggle(@PathParam("id") Long id) {
+        Instructor instructor = repository.findById(id);
+        instructor.active = !instructor.active;
+        repository.persist(instructor);
+        repository.flush();
+        return list();
+    }
+}
+

--- a/src/main/resources/templates/admin/instructor-form.html
+++ b/src/main/resources/templates/admin/instructor-form.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Edit Instructor</title>
+</head>
+<body>
+<div id="navigation">
+    {#include admin/navigation}{/include}
+</div>
+<main>
+    <h1>Edit Instructor</h1>
+    <form action="/admin/instructors/{instructor.id}/edit" method="post">
+        <input type="text" name="firstName" value="{instructor.firstName}" required>
+        <input type="text" name="lastName" value="{instructor.lastName}" required>
+        <input type="email" name="email" value="{instructor.email}">
+        <input type="text" name="phone" value="{instructor.phone}">
+        <input type="text" name="availability" value="{instructor.availability}">
+        <input type="number" name="defaultSlotDuration" value="{instructor.defaultSlotDuration}">
+        <label>
+            Active <input type="checkbox" name="active" value="true" {#if instructor.active}checked{/if}>
+        </label>
+        <button type="submit">Save</button>
+    </form>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/instructors.html
+++ b/src/main/resources/templates/admin/instructors.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Instructors</title>
+</head>
+<body>
+<div id="navigation">
+    {#include admin/navigation}{/include}
+</div>
+<main>
+    <h1>Instructors</h1>
+    <h2>Add Instructor</h2>
+    <form action="/admin/instructors" method="post">
+        <input type="text" name="firstName" placeholder="First name" required>
+        <input type="text" name="lastName" placeholder="Last name" required>
+        <input type="email" name="email" placeholder="Email">
+        <input type="text" name="phone" placeholder="Phone">
+        <input type="text" name="availability" placeholder="Availability">
+        <input type="number" name="defaultSlotDuration" placeholder="Slot duration">
+        <button type="submit">Add</button>
+    </form>
+
+    <h2>Existing Instructors</h2>
+    <table>
+        <thead>
+        <tr><th>Name</th><th>Active</th><th>Actions</th></tr>
+        </thead>
+        <tbody>
+        {#for i in instructors}
+        <tr>
+            <td>{i.firstName} {i.lastName}</td>
+            <td>{i.active ? 'Yes' : 'No'}</td>
+            <td>
+                <form action="/admin/instructors/{i.id}/edit" method="get" style="display:inline">
+                    <button type="submit">Edit</button>
+                </form>
+                <form action="/admin/instructors/{i.id}/toggle" method="post" style="display:inline">
+                    <button type="submit">{i.active ? 'Disable' : 'Enable'}</button>
+                </form>
+            </td>
+        </tr>
+        {/for}
+        </tbody>
+    </table>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/navigation.html
+++ b/src/main/resources/templates/admin/navigation.html
@@ -1,5 +1,6 @@
 <nav>
     <ul>
         <li><a href="/admin/">Home</a></li>
+        <li><a href="/admin/instructors">Instructors</a></li>
     </ul>
 </nav>

--- a/src/test/java/org/acme/InstructorAdminResourceIT.java
+++ b/src/test/java/org/acme/InstructorAdminResourceIT.java
@@ -1,0 +1,8 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+class InstructorAdminResourceIT extends InstructorAdminResourceTest {
+    // tests are inherited
+}

--- a/src/test/java/org/acme/InstructorAdminResourceTest.java
+++ b/src/test/java/org/acme/InstructorAdminResourceTest.java
@@ -1,0 +1,42 @@
+package org.acme;
+
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.acme.domain.Instructor;
+import org.acme.repository.InstructorRepository;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+class InstructorAdminResourceTest {
+
+    @Inject
+    InstructorRepository repository;
+
+    @Test
+    void testListProtected() {
+        given()
+          .when().get("/admin/instructors")
+          .then()
+             .statusCode(401);
+    }
+
+    @Test
+    @TestTransaction
+    void testListWithAuth() {
+        Instructor ins = new Instructor();
+        ins.firstName = "Mary";
+        ins.lastName = "Poppins";
+        repository.persist(ins);
+
+        given()
+          .auth().preemptive().basic("admin", "secret")
+          .when().get("/admin/instructors")
+          .then()
+             .statusCode(200)
+             .body(containsString("Mary"));
+    }
+}


### PR DESCRIPTION
## Summary
- add InstructorAdminResource for admin operations
- update navigation with Instructors link
- create templates for adding and editing instructors
- test instructor admin HTTP endpoint

## Testing
- `mvn -q verify` *(fails: could not find Docker to start Dev Services)*

------
https://chatgpt.com/codex/tasks/task_e_685445be1a088328b0e0b5728772a5b6