### PR TITLE
Implement enum availability and multi-slot durations

### DIFF
--- a/src/main/java/org/acme/admin/InstructorAdminResource.java
+++ b/src/main/java/org/acme/admin/InstructorAdminResource.java
@@ -11,7 +11,10 @@ import jakarta.transaction.Transactional;
 import org.acme.domain.Instructor;
 import org.acme.repository.InstructorRepository;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Path("/admin/instructors")
 @RolesAllowed("admin")
@@ -42,15 +45,20 @@ public class InstructorAdminResource {
                                    @FormParam("lastName") String lastName,
                                    @FormParam("email") String email,
                                    @FormParam("phone") String phone,
-                                   @FormParam("availability") String availability,
-                                   @FormParam("defaultSlotDuration") Integer defaultSlotDuration) {
+                                   @FormParam("availability") List<String> availability,
+                                   @FormParam("slotDurations") List<String> slotDurations) {
         Instructor instructor = new Instructor();
         instructor.firstName = firstName;
         instructor.lastName = lastName;
         instructor.email = email;
         instructor.phone = phone;
-        instructor.availability = availability;
-        instructor.defaultSlotDuration = defaultSlotDuration;
+        instructor.availability = availability.stream()
+                .map(String::toUpperCase)
+                .map(DayOfWeek::valueOf)
+                .collect(Collectors.toSet());
+        instructor.slotDurations = slotDurations.stream()
+                .map(Integer::valueOf)
+                .collect(Collectors.toSet());
         repository.persist(instructor);
         return list();
     }
@@ -72,16 +80,21 @@ public class InstructorAdminResource {
                                    @FormParam("lastName") String lastName,
                                    @FormParam("email") String email,
                                    @FormParam("phone") String phone,
-                                   @FormParam("availability") String availability,
-                                   @FormParam("defaultSlotDuration") Integer defaultSlotDuration,
+                                   @FormParam("availability") List<String> availability,
+                                   @FormParam("slotDurations") List<String> slotDurations,
                                    @FormParam("active") boolean active) {
         Instructor instructor = repository.findById(id);
         instructor.firstName = firstName;
         instructor.lastName = lastName;
         instructor.email = email;
         instructor.phone = phone;
-        instructor.availability = availability;
-        instructor.defaultSlotDuration = defaultSlotDuration;
+        instructor.availability = availability.stream()
+                .map(String::toUpperCase)
+                .map(DayOfWeek::valueOf)
+                .collect(Collectors.toSet());
+        instructor.slotDurations = slotDurations.stream()
+                .map(Integer::valueOf)
+                .collect(Collectors.toSet());
         instructor.active = active;
         repository.persist(instructor);
         repository.flush();

--- a/src/main/java/org/acme/domain/Instructor.java
+++ b/src/main/java/org/acme/domain/Instructor.java
@@ -4,6 +4,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.DayOfWeek;
+import java.util.Set;
 
 @Entity
 public class Instructor {
@@ -15,12 +20,16 @@ public class Instructor {
     public String lastName;
     public String email;
     public String phone;
-    public Integer defaultSlotDuration;
+
+    @ElementCollection
+    public Set<Integer> slotDurations;
 
     /**
-     * Text description of the instructor's general availability.
+     * Days of the week the instructor is generally available.
      */
-    public String availability;
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    public Set<DayOfWeek> availability;
 
     /**
      * Flag indicating if this instructor can currently be booked.

--- a/src/main/resources/templates/admin/instructor-form.html
+++ b/src/main/resources/templates/admin/instructor-form.html
@@ -15,8 +15,23 @@
         <input type="text" name="lastName" value="{instructor.lastName}" required>
         <input type="email" name="email" value="{instructor.email}">
         <input type="text" name="phone" value="{instructor.phone}">
-        <input type="text" name="availability" value="{instructor.availability}">
-        <input type="number" name="defaultSlotDuration" value="{instructor.defaultSlotDuration}">
+        <div>
+            <span>Availability:</span>
+            <label><input type="checkbox" name="availability" value="MONDAY" {#if instructor.availability.contains('MONDAY')}checked{/if}>Mon</label>
+            <label><input type="checkbox" name="availability" value="TUESDAY" {#if instructor.availability.contains('TUESDAY')}checked{/if}>Tue</label>
+            <label><input type="checkbox" name="availability" value="WEDNESDAY" {#if instructor.availability.contains('WEDNESDAY')}checked{/if}>Wed</label>
+            <label><input type="checkbox" name="availability" value="THURSDAY" {#if instructor.availability.contains('THURSDAY')}checked{/if}>Thu</label>
+            <label><input type="checkbox" name="availability" value="FRIDAY" {#if instructor.availability.contains('FRIDAY')}checked{/if}>Fri</label>
+            <label><input type="checkbox" name="availability" value="SATURDAY" {#if instructor.availability.contains('SATURDAY')}checked{/if}>Sat</label>
+            <label><input type="checkbox" name="availability" value="SUNDAY" {#if instructor.availability.contains('SUNDAY')}checked{/if}>Sun</label>
+        </div>
+        <div>
+            <span>Slot Durations:</span>
+            <label><input type="checkbox" name="slotDurations" value="30" {#if instructor.slotDurations.contains(30)}checked{/if}>30</label>
+            <label><input type="checkbox" name="slotDurations" value="60" {#if instructor.slotDurations.contains(60)}checked{/if}>60</label>
+            <label><input type="checkbox" name="slotDurations" value="90" {#if instructor.slotDurations.contains(90)}checked{/if}>90</label>
+            <label><input type="checkbox" name="slotDurations" value="120" {#if instructor.slotDurations.contains(120)}checked{/if}>120</label>
+        </div>
         <label>
             Active <input type="checkbox" name="active" value="true" {#if instructor.active}checked{/if}>
         </label>

--- a/src/main/resources/templates/admin/instructors.html
+++ b/src/main/resources/templates/admin/instructors.html
@@ -16,8 +16,23 @@
         <input type="text" name="lastName" placeholder="Last name" required>
         <input type="email" name="email" placeholder="Email">
         <input type="text" name="phone" placeholder="Phone">
-        <input type="text" name="availability" placeholder="Availability">
-        <input type="number" name="defaultSlotDuration" placeholder="Slot duration">
+        <div>
+            <span>Availability:</span>
+            <label><input type="checkbox" name="availability" value="MONDAY">Mon</label>
+            <label><input type="checkbox" name="availability" value="TUESDAY">Tue</label>
+            <label><input type="checkbox" name="availability" value="WEDNESDAY">Wed</label>
+            <label><input type="checkbox" name="availability" value="THURSDAY">Thu</label>
+            <label><input type="checkbox" name="availability" value="FRIDAY">Fri</label>
+            <label><input type="checkbox" name="availability" value="SATURDAY">Sat</label>
+            <label><input type="checkbox" name="availability" value="SUNDAY">Sun</label>
+        </div>
+        <div>
+            <span>Slot Durations:</span>
+            <label><input type="checkbox" name="slotDurations" value="30">30</label>
+            <label><input type="checkbox" name="slotDurations" value="60">60</label>
+            <label><input type="checkbox" name="slotDurations" value="90">90</label>
+            <label><input type="checkbox" name="slotDurations" value="120">120</label>
+        </div>
         <button type="submit">Add</button>
     </form>
 

--- a/src/test/java/org/acme/InstructorRepositoryTest.java
+++ b/src/test/java/org/acme/InstructorRepositoryTest.java
@@ -5,6 +5,8 @@ import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.acme.domain.Instructor;
 import org.acme.repository.InstructorRepository;
+import java.time.DayOfWeek;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,7 +23,8 @@ class InstructorRepositoryTest {
         Instructor ins = new Instructor();
         ins.firstName = "John";
         ins.lastName = "Doe";
-        ins.availability = "Weekdays";
+        ins.availability = Set.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY);
+        ins.slotDurations = Set.of(30, 60);
         repository.persist(ins);
 
         assertNotNull(ins.id);
@@ -32,14 +35,16 @@ class InstructorRepositoryTest {
 
         found.firstName = "Jane";
         found.active = false;
-        found.availability = "Weekends";
+        found.availability = Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+        found.slotDurations = Set.of(90);
         repository.persist(found);
         repository.flush();
 
         Instructor updated = repository.findById(ins.id);
         assertEquals("Jane", updated.firstName);
         assertFalse(updated.active);
-        assertEquals("Weekends", updated.availability);
+        assertEquals(Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY), updated.availability);
+        assertEquals(Set.of(90), updated.slotDurations);
 
         repository.delete(updated);
         assertNull(repository.findById(ins.id));


### PR DESCRIPTION
## What changed?
- Updated `Instructor` entity to store availability as a set of `DayOfWeek` and allow multiple slot durations.
- Adjusted admin resource to parse checkbox form fields and persist new collections.
- Updated admin HTML forms to provide weekday and slot duration checkboxes.
- Revised repository test to work with new fields.

## Why?
- To represent instructor availability as specific weekdays and allow multiple slot length options.

## Breaking changes?
- `Instructor` API and database schema changed: `availability` is now a collection of weekdays and `slotDurations` replaces `defaultSlotDuration`.


------
https://chatgpt.com/codex/tasks/task_e_68545b68ecd48328a41fa7b228e6732c