### PR TITLE
Add DB security and student profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-elytron-security-properties-file</artifactId>
+            <artifactId>quarkus-elytron-security-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/java/org/acme/admin/InstructorAdminResource.java
+++ b/src/main/java/org/acme/admin/InstructorAdminResource.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.transaction.Transactional;
+import io.quarkus.elytron.security.common.BcryptUtil;
 import org.acme.domain.Instructor;
 import org.acme.repository.InstructorRepository;
 
@@ -45,6 +46,8 @@ public class InstructorAdminResource {
                                    @FormParam("lastName") String lastName,
                                    @FormParam("email") String email,
                                    @FormParam("phone") String phone,
+                                   @FormParam("username") String username,
+                                   @FormParam("password") String password,
                                    @FormParam("availability") List<String> availability,
                                    @FormParam("slotDurations") List<String> slotDurations) {
         Instructor instructor = new Instructor();
@@ -52,6 +55,8 @@ public class InstructorAdminResource {
         instructor.lastName = lastName;
         instructor.email = email;
         instructor.phone = phone;
+        instructor.username = username;
+        instructor.password = BcryptUtil.bcryptHash(password);
         instructor.availability = availability.stream()
                 .map(String::toUpperCase)
                 .map(DayOfWeek::valueOf)

--- a/src/main/java/org/acme/admin/StudentAdminResource.java
+++ b/src/main/java/org/acme/admin/StudentAdminResource.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import org.acme.domain.Student;
 import org.acme.repository.StudentRepository;
+import io.quarkus.elytron.security.common.BcryptUtil;
 
 import java.util.List;
 
@@ -42,12 +43,16 @@ public class StudentAdminResource {
     public TemplateInstance create(@FormParam("firstName") String firstName,
                                    @FormParam("lastName") String lastName,
                                    @FormParam("email") String email,
-                                   @FormParam("phone") String phone) {
+                                   @FormParam("phone") String phone,
+                                   @FormParam("username") String username,
+                                   @FormParam("password") String password) {
         Student student = new Student();
         student.firstName = firstName;
         student.lastName = lastName;
         student.email = email;
         student.phone = phone;
+        student.username = username;
+        student.password = BcryptUtil.bcryptHash(password);
         repository.persist(student);
         return list();
     }

--- a/src/main/java/org/acme/domain/Admin.java
+++ b/src/main/java/org/acme/domain/Admin.java
@@ -1,0 +1,16 @@
+package org.acme.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Admin {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    public String username;
+    public String password;
+}

--- a/src/main/java/org/acme/domain/Instructor.java
+++ b/src/main/java/org/acme/domain/Instructor.java
@@ -21,6 +21,9 @@ public class Instructor {
     public String email;
     public String phone;
 
+    public String username;
+    public String password;
+
     @ElementCollection
     public Set<Integer> slotDurations;
 

--- a/src/main/java/org/acme/domain/Student.java
+++ b/src/main/java/org/acme/domain/Student.java
@@ -21,6 +21,9 @@ public class Student {
     public String email;
     public String phone;
 
+    public String username;
+    public String password;
+
     /**
      * Optional preferred instructor for this student.
      */

--- a/src/main/java/org/acme/repository/AdminRepository.java
+++ b/src/main/java/org/acme/repository/AdminRepository.java
@@ -1,0 +1,9 @@
+package org.acme.repository;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.acme.domain.Admin;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+
+@ApplicationScoped
+public class AdminRepository implements PanacheRepository<Admin> {
+}

--- a/src/main/java/org/acme/security/DatabaseIdentityProvider.java
+++ b/src/main/java/org/acme/security/DatabaseIdentityProvider.java
@@ -1,0 +1,68 @@
+package org.acme.security;
+
+import io.quarkus.elytron.security.common.BcryptUtil;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.acme.domain.Admin;
+import org.acme.domain.Instructor;
+import org.acme.domain.Student;
+import org.acme.repository.AdminRepository;
+import org.acme.repository.InstructorRepository;
+import org.acme.repository.StudentRepository;
+
+@ApplicationScoped
+public class DatabaseIdentityProvider implements IdentityProvider<UsernamePasswordAuthenticationRequest> {
+
+    @Inject
+    AdminRepository adminRepository;
+    @Inject
+    InstructorRepository instructorRepository;
+    @Inject
+    StudentRepository studentRepository;
+
+    @Override
+    public Class<UsernamePasswordAuthenticationRequest> getRequestType() {
+        return UsernamePasswordAuthenticationRequest.class;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(UsernamePasswordAuthenticationRequest request, AuthenticationRequestContext context) {
+        String username = request.getUsername();
+        String password = new String(request.getPassword().getPassword());
+        return context.runBlocking(() -> doAuth(username, password));
+    }
+
+    @Transactional
+    @ActivateRequestContext
+    SecurityIdentity doAuth(String username, String password) {
+        Admin admin = adminRepository.find("username", username).firstResult();
+        if (admin != null && BcryptUtil.matches(password, admin.password)) {
+            return buildIdentity(username, "admin");
+        }
+        Instructor instructor = instructorRepository.find("username", username).firstResult();
+        if (instructor != null && BcryptUtil.matches(password, instructor.password)) {
+            return buildIdentity(username, "instructor");
+        }
+        Student student = studentRepository.find("username", username).firstResult();
+        if (student != null && BcryptUtil.matches(password, student.password)) {
+            return buildIdentity(username, "student");
+        }
+        return null;
+    }
+
+    private SecurityIdentity buildIdentity(String username, String role) {
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder();
+        builder.setPrincipal(new QuarkusPrincipal(username));
+        builder.addRole(role);
+        return builder.build();
+    }
+}

--- a/src/main/java/org/acme/student/StudentResource.java
+++ b/src/main/java/org/acme/student/StudentResource.java
@@ -5,12 +5,19 @@ import io.quarkus.qute.Template;
 import io.quarkus.qute.TemplateInstance;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import io.quarkus.elytron.security.common.BcryptUtil;
+import org.acme.domain.Student;
+import org.acme.repository.StudentRepository;
 
 @Path("/student")
 public class StudentResource {
@@ -19,10 +26,50 @@ public class StudentResource {
     @Location("student/index")
     Template index;
 
+    @Inject
+    @Location("student/profile")
+    Template profile;
+
+    @Inject
+    StudentRepository repository;
+
     @GET
     @Produces(MediaType.TEXT_HTML)
     @RolesAllowed("student")
     public TemplateInstance index(@Context SecurityContext ctx) {
         return index.data("user", ctx.getUserPrincipal().getName());
+    }
+
+    @GET
+    @Path("/profile")
+    @Produces(MediaType.TEXT_HTML)
+    @RolesAllowed("student")
+    public TemplateInstance profile(@Context SecurityContext ctx) {
+        Student student = repository.find("username", ctx.getUserPrincipal().getName()).firstResult();
+        return profile.data("student", student);
+    }
+
+    @POST
+    @Path("/profile")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Transactional
+    @RolesAllowed("student")
+    public TemplateInstance update(@Context SecurityContext ctx,
+                                   @FormParam("firstName") String firstName,
+                                   @FormParam("lastName") String lastName,
+                                   @FormParam("email") String email,
+                                   @FormParam("phone") String phone,
+                                   @FormParam("password") String password) {
+        Student student = repository.find("username", ctx.getUserPrincipal().getName()).firstResult();
+        student.firstName = firstName;
+        student.lastName = lastName;
+        student.email = email;
+        student.phone = phone;
+        if (password != null && !password.isEmpty()) {
+            student.password = BcryptUtil.bcryptHash(password);
+        }
+        repository.persist(student);
+        repository.flush();
+        return profile.data("student", student);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,4 @@
 quarkus.http.auth.basic=true
-quarkus.security.users.embedded.enabled=true
-quarkus.security.users.embedded.plain-text=true
-quarkus.security.users.embedded.users.admin=secret
-quarkus.security.users.embedded.users.student=generated
-quarkus.security.users.embedded.roles.admin=admin
-quarkus.security.users.embedded.roles.student=student
 quarkus.datasource.db-kind=h2
 quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.security.jdbc.principal-query.sql=SELECT password, role FROM (SELECT username, password, 'admin' role FROM admin UNION ALL SELECT username, password, 'instructor' role FROM instructor UNION ALL SELECT username, password, 'student' role FROM student) u WHERE username=?

--- a/src/main/resources/templates/admin/instructors.html
+++ b/src/main/resources/templates/admin/instructors.html
@@ -16,6 +16,8 @@
         <input type="text" name="lastName" placeholder="Last name" required>
         <input type="email" name="email" placeholder="Email">
         <input type="text" name="phone" placeholder="Phone">
+        <input type="text" name="username" placeholder="Username" required>
+        <input type="password" name="password" placeholder="Password" required>
         <div>
             <span>Availability:</span>
             <label><input type="checkbox" name="availability" value="MONDAY">Mon</label>

--- a/src/main/resources/templates/admin/students.html
+++ b/src/main/resources/templates/admin/students.html
@@ -16,6 +16,8 @@
         <input type="text" name="lastName" placeholder="Last name" required>
         <input type="email" name="email" placeholder="Email" required>
         <input type="text" name="phone" placeholder="Phone">
+        <input type="text" name="username" placeholder="Username" required>
+        <input type="password" name="password" placeholder="Password" required>
         <button type="submit">Add</button>
     </form>
 

--- a/src/main/resources/templates/student/index.html
+++ b/src/main/resources/templates/student/index.html
@@ -8,6 +8,7 @@
 <main>
     <h1>Welcome, {user}</h1>
     <p>Please change your password.</p>
+    <p><a href="/student/profile">Edit Profile</a></p>
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/student/profile.html
+++ b/src/main/resources/templates/student/profile.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Profile</title>
+</head>
+<body>
+<main>
+    <h1>Edit Profile</h1>
+    <form action="/student/profile" method="post">
+        <input type="text" name="firstName" value="{student.firstName}" required>
+        <input type="text" name="lastName" value="{student.lastName}" required>
+        <input type="email" name="email" value="{student.email}">
+        <input type="text" name="phone" value="{student.phone}">
+        <input type="password" name="password" placeholder="New password">
+        <button type="submit">Save</button>
+    </form>
+</main>
+</body>
+</html>

--- a/src/test/java/org/acme/AdminResourceTest.java
+++ b/src/test/java/org/acme/AdminResourceTest.java
@@ -1,6 +1,12 @@
 package org.acme;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.elytron.security.common.BcryptUtil;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.acme.domain.Admin;
+import org.acme.repository.AdminRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -8,6 +14,21 @@ import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
 class AdminResourceTest {
+
+    @Inject
+    AdminRepository adminRepository;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        if (adminRepository.count() == 0) {
+            Admin admin = new Admin();
+            admin.username = "admin";
+            admin.password = BcryptUtil.bcryptHash("secret");
+            adminRepository.persist(admin);
+            adminRepository.flush();
+        }
+    }
 
     @Test
     void testAdminEndpointProtected() {

--- a/src/test/java/org/acme/InstructorAdminResourceTest.java
+++ b/src/test/java/org/acme/InstructorAdminResourceTest.java
@@ -1,6 +1,12 @@
 package org.acme;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.elytron.security.common.BcryptUtil;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.acme.domain.Admin;
+import org.acme.repository.AdminRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -8,6 +14,21 @@ import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
 class InstructorAdminResourceTest {
+
+    @Inject
+    AdminRepository adminRepository;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        if (adminRepository.count() == 0) {
+            Admin admin = new Admin();
+            admin.username = "admin";
+            admin.password = BcryptUtil.bcryptHash("secret");
+            adminRepository.persist(admin);
+            adminRepository.flush();
+        }
+    }
 
 
     @Test
@@ -24,6 +45,8 @@ class InstructorAdminResourceTest {
           .auth().preemptive().basic("admin", "secret")
           .formParam("firstName", "Mary")
           .formParam("lastName", "Poppins")
+          .formParam("username", "mary")
+          .formParam("password", "pwd")
           .when().post("/admin/instructors")
           .then()
              .statusCode(200);

--- a/src/test/java/org/acme/StudentAdminResourceTest.java
+++ b/src/test/java/org/acme/StudentAdminResourceTest.java
@@ -1,6 +1,12 @@
 package org.acme;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.elytron.security.common.BcryptUtil;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.acme.domain.Admin;
+import org.acme.repository.AdminRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -8,6 +14,21 @@ import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
 class StudentAdminResourceTest {
+
+    @Inject
+    AdminRepository adminRepository;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        if (adminRepository.count() == 0) {
+            Admin admin = new Admin();
+            admin.username = "admin";
+            admin.password = BcryptUtil.bcryptHash("secret");
+            adminRepository.persist(admin);
+            adminRepository.flush();
+        }
+    }
 
     @Test
     void testListProtected() {
@@ -24,6 +45,8 @@ class StudentAdminResourceTest {
           .formParam("firstName", "John")
           .formParam("lastName", "Doe")
           .formParam("email", "john@example.com")
+          .formParam("username", "john")
+          .formParam("password", "pwd")
           .when().post("/admin/students")
           .then()
              .statusCode(200);

--- a/src/test/java/org/acme/StudentResourceTest.java
+++ b/src/test/java/org/acme/StudentResourceTest.java
@@ -1,6 +1,12 @@
 package org.acme;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.elytron.security.common.BcryptUtil;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.acme.domain.Student;
+import org.acme.repository.StudentRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -8,6 +14,21 @@ import static org.hamcrest.Matchers.containsString;
 
 @QuarkusTest
 class StudentResourceTest {
+
+    @Inject
+    StudentRepository studentRepository;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        if (studentRepository.find("username", "student").firstResult() == null) {
+            Student student = new Student();
+            student.username = "student";
+            student.password = BcryptUtil.bcryptHash("generated");
+            studentRepository.persist(student);
+            studentRepository.flush();
+        }
+    }
 
     @Test
     void testStudentEndpointProtected() {


### PR DESCRIPTION
## Summary
- implement database-backed login with bcrypt password checking
- add hashed credentials when admins, instructors, and students are created
- enable students to update their profiles with a new password
- configure JDBC realm to query all user tables

## Testing
- `mvn -q compile`
- `mvn -q verify`


------
https://chatgpt.com/codex/tasks/task_e_68546271b4f48328b2bc8a7d2634209b