### PR TITLE
Add schedule management

### DIFF
--- a/src/main/java/org/acme/LessonSlotResource.java
+++ b/src/main/java/org/acme/LessonSlotResource.java
@@ -1,0 +1,28 @@
+package org.acme;
+
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.acme.repository.LessonSlotRepository;
+
+@Path("/schedule")
+public class LessonSlotResource {
+
+    @Inject
+    LessonSlotRepository repository;
+
+    @Inject
+    @Location("schedule/index")
+    Template index;
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance list() {
+        return index.data("slots", repository.listAll());
+    }
+}

--- a/src/main/java/org/acme/admin/LessonSlotAdminResource.java
+++ b/src/main/java/org/acme/admin/LessonSlotAdminResource.java
@@ -1,0 +1,75 @@
+package org.acme.admin;
+
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.acme.domain.LessonSlot;
+import org.acme.domain.Instructor;
+import org.acme.domain.Horse;
+import org.acme.repository.LessonSlotRepository;
+import org.acme.repository.InstructorRepository;
+import org.acme.repository.HorseRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Path("/admin/lesson-slots")
+@RolesAllowed("admin")
+public class LessonSlotAdminResource {
+
+    @Inject
+    LessonSlotRepository repository;
+
+    @Inject
+    InstructorRepository instructorRepository;
+
+    @Inject
+    HorseRepository horseRepository;
+
+    @Inject
+    @Location("admin/lesson-slots")
+    Template index;
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance list() {
+        List<LessonSlot> slots = repository.listAll();
+        List<Instructor> instructors = instructorRepository.listAll();
+        List<Horse> horses = horseRepository.listAll();
+        return index.data("slots", slots)
+                    .data("instructors", instructors)
+                    .data("horses", horses);
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Transactional
+    public TemplateInstance create(@FormParam("startTime") String startTime,
+                                   @FormParam("endTime") String endTime,
+                                   @FormParam("instructorId") Long instructorId,
+                                   @FormParam("horseId") Long horseId) {
+        LessonSlot slot = new LessonSlot();
+        slot.startTime = LocalDateTime.parse(startTime);
+        slot.endTime = LocalDateTime.parse(endTime);
+        slot.instructor = instructorRepository.findById(instructorId);
+        if (horseId != null) {
+            slot.horse = horseRepository.findById(horseId);
+        }
+        repository.persist(slot);
+        return list();
+    }
+
+    @POST
+    @Path("{id}/delete")
+    @Transactional
+    public TemplateInstance delete(@PathParam("id") Long id) {
+        repository.deleteById(id);
+        repository.flush();
+        return list();
+    }
+}

--- a/src/main/resources/templates/admin/lesson-slots.html
+++ b/src/main/resources/templates/admin/lesson-slots.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Schedule</title>
+</head>
+<body>
+<div id="navigation">
+    {#include admin/navigation}{/include}
+</div>
+<main>
+    <h1>Schedule</h1>
+    <h2>Add Lesson Slot</h2>
+    <form action="/admin/lesson-slots" method="post">
+        <input type="datetime-local" name="startTime" required>
+        <input type="datetime-local" name="endTime" required>
+        <select name="instructorId">
+            {#for i in instructors}
+            <option value="{i.id}">{i.firstName} {i.lastName}</option>
+            {/for}
+        </select>
+        <select name="horseId">
+            <option value="">None</option>
+            {#for h in horses}
+            <option value="{h.id}">{h.name}</option>
+            {/for}
+        </select>
+        <button type="submit">Add</button>
+    </form>
+
+    <h2>Existing Slots</h2>
+    <table>
+        <thead>
+        <tr><th>Start</th><th>End</th><th>Instructor</th><th>Horse</th><th>Actions</th></tr>
+        </thead>
+        <tbody>
+        {#for s in slots}
+        <tr>
+            <td>{s.startTime}</td>
+            <td>{s.endTime}</td>
+            <td>{s.instructor.firstName}</td>
+            <td>{s.horse != null ? s.horse.name : ''}</td>
+            <td>
+                <form action="/admin/lesson-slots/{s.id}/delete" method="post" style="display:inline">
+                    <button type="submit">Delete</button>
+                </form>
+            </td>
+        </tr>
+        {/for}
+        </tbody>
+    </table>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/navigation.html
+++ b/src/main/resources/templates/admin/navigation.html
@@ -4,5 +4,6 @@
         <li><a href="/admin/instructors">Instructors</a></li>
         <li><a href="/admin/students">Students</a></li>
         <li><a href="/admin/horses">Horses</a></li>
+        <li><a href="/admin/lesson-slots">Schedule</a></li>
     </ul>
 </nav>

--- a/src/main/resources/templates/schedule/index.html
+++ b/src/main/resources/templates/schedule/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Available Slots</title>
+</head>
+<body>
+<main>
+    <h1>Available Lesson Slots</h1>
+    <ul>
+        {#for s in slots}
+        <li>{s.startTime} - {s.endTime} with {s.instructor.firstName}{#if s.horse} riding {s.horse.name}{/if}</li>
+        {/for}
+    </ul>
+</main>
+</body>
+</html>

--- a/src/test/java/org/acme/LessonSlotAdminResourceIT.java
+++ b/src/test/java/org/acme/LessonSlotAdminResourceIT.java
@@ -1,0 +1,10 @@
+package org.acme;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(CustomH2DatabaseTestResource.class)
+class LessonSlotAdminResourceIT extends LessonSlotAdminResourceTest {
+    // tests are inherited
+}

--- a/src/test/java/org/acme/LessonSlotAdminResourceTest.java
+++ b/src/test/java/org/acme/LessonSlotAdminResourceTest.java
@@ -1,0 +1,87 @@
+package org.acme;
+
+import io.quarkus.elytron.security.common.BcryptUtil;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.acme.domain.Admin;
+import org.acme.domain.Horse;
+import org.acme.domain.Instructor;
+import org.acme.repository.AdminRepository;
+import org.acme.repository.HorseRepository;
+import org.acme.repository.InstructorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+class LessonSlotAdminResourceTest {
+
+    @Inject
+    AdminRepository adminRepository;
+
+    @Inject
+    InstructorRepository instructorRepository;
+
+    @Inject
+    HorseRepository horseRepository;
+
+    Long instructorId;
+    Long horseId;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        Admin admin = adminRepository.find("username", "admin").firstResult();
+        if (admin == null) {
+            admin = new Admin();
+            admin.username = "admin";
+        }
+        admin.password = BcryptUtil.bcryptHash("secret");
+        adminRepository.persist(admin);
+
+        Instructor ins = new Instructor();
+        ins.firstName = "Tina";
+        instructorRepository.persist(ins);
+        instructorId = ins.id;
+
+        Horse horse = new Horse();
+        horse.name = "Bolt";
+        horseRepository.persist(horse);
+        horseId = horse.id;
+
+        adminRepository.flush();
+        instructorRepository.flush();
+        horseRepository.flush();
+    }
+
+    @Test
+    void testListProtected() {
+        given()
+          .when().get("/admin/lesson-slots")
+          .then()
+             .statusCode(401);
+    }
+
+    @Test
+    void testCreateAndListWithAuth() {
+        given()
+          .auth().preemptive().basic("admin", "secret")
+          .formParam("startTime", "2024-01-01T10:00")
+          .formParam("endTime", "2024-01-01T11:00")
+          .formParam("instructorId", instructorId)
+          .formParam("horseId", horseId)
+          .when().post("/admin/lesson-slots")
+          .then()
+             .statusCode(200);
+
+        given()
+          .auth().preemptive().basic("admin", "secret")
+          .when().get("/admin/lesson-slots")
+          .then()
+             .statusCode(200)
+             .body(containsString("Bolt"));
+    }
+}

--- a/src/test/java/org/acme/LessonSlotResourceIT.java
+++ b/src/test/java/org/acme/LessonSlotResourceIT.java
@@ -1,0 +1,10 @@
+package org.acme;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+@QuarkusTestResource(CustomH2DatabaseTestResource.class)
+class LessonSlotResourceIT extends LessonSlotResourceTest {
+    // tests are inherited
+}

--- a/src/test/java/org/acme/LessonSlotResourceTest.java
+++ b/src/test/java/org/acme/LessonSlotResourceTest.java
@@ -1,0 +1,49 @@
+package org.acme;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.TestTransaction;
+import jakarta.inject.Inject;
+import org.acme.domain.Instructor;
+import org.acme.domain.LessonSlot;
+import org.acme.repository.InstructorRepository;
+import org.acme.repository.LessonSlotRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+class LessonSlotResourceTest {
+
+    @Inject
+    LessonSlotRepository repository;
+
+    @Inject
+    InstructorRepository instructorRepository;
+
+    @BeforeEach
+    @TestTransaction
+    void setUp() {
+        Instructor ins = new Instructor();
+        ins.firstName = "Paul";
+        instructorRepository.persist(ins);
+
+        LessonSlot slot = new LessonSlot();
+        slot.startTime = LocalDateTime.of(2024,1,1,9,0);
+        slot.endTime = LocalDateTime.of(2024,1,1,10,0);
+        slot.instructor = ins;
+        repository.persist(slot);
+    }
+
+    @Test
+    void testSchedulePage() {
+        given()
+          .when().get("/schedule")
+          .then()
+             .statusCode(200)
+             .body(containsString("Available Lesson Slots"));
+    }
+}


### PR DESCRIPTION
## What changed?
- added admin resource for lesson slots
- added schedule page and templates
- exposed public schedule listing
- added tests for lesson slot endpoints

## Why?
- implements schedule management as outlined in PRD

## Breaking changes?
- none

------
https://chatgpt.com/codex/tasks/task_e_6854781b064483289daeeb6d16f6fe48